### PR TITLE
feat: implement backend authentication with passport and JWT

### DIFF
--- a/backend/prisma/migrations/20250527_add_username_to_user/migration.sql
+++ b/backend/prisma/migrations/20250527_add_username_to_user/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "username" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,6 +16,7 @@ datasource db {
 model User {
   id        String   @id @default(cuid())
   email     String   @unique
+  username  String   @unique
   password  String
   name      String?
   createdAt DateTime @default(now())

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { ItemsModule } from './items/items.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { UsersModule } from './users/users.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UsersModule } from './users/users.module';
     ItemsModule,
     PrismaModule,
     UsersModule,
+    AuthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AuthService } from './auth.service';
+import { AuthResolver } from './auth.resolver';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { LocalStrategy } from './strategies/local.strategy';
+import { UsersModule } from '../users/users.module';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [
+    PassportModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'defaultSecret',
+      signOptions: { expiresIn: '7d' },
+    }),
+    UsersModule,
+    PrismaModule,
+  ],
+  providers: [AuthService, AuthResolver, JwtStrategy, LocalStrategy],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.resolver.ts
+++ b/backend/src/auth/auth.resolver.ts
@@ -1,0 +1,20 @@
+import { Resolver, Mutation, Args } from '@nestjs/graphql';
+import { AuthService } from './auth.service';
+import { RegisterInput } from './dto/register.input';
+import { LoginInput } from './dto/login.input';
+import { AuthResponse } from './dto/auth-response';
+
+@Resolver()
+export class AuthResolver {
+  constructor(private readonly authService: AuthService) {}
+
+  @Mutation(() => AuthResponse)
+  async register(@Args('registerInput') registerInput: RegisterInput): Promise<AuthResponse> {
+    return this.authService.register(registerInput);
+  }
+
+  @Mutation(() => AuthResponse)
+  async login(@Args('loginInput') loginInput: LoginInput): Promise<AuthResponse> {
+    return this.authService.login(loginInput);
+  }
+}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, ConflictException, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma/prisma.service';
+import { RegisterInput } from './dto/register.input';
+import { LoginInput } from './dto/login.input';
+import { AuthResponse } from './dto/auth-response';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private prisma: PrismaService,
+    private jwtService: JwtService,
+  ) {}
+
+  async register(registerInput: RegisterInput): Promise<AuthResponse> {
+    const { email, username, password, name } = registerInput;
+
+    const existingUserByEmail = await this.prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (existingUserByEmail) {
+      throw new ConflictException('Email already exists');
+    }
+
+    const existingUserByUsername = await this.prisma.user.findUnique({
+      where: { username },
+    });
+
+    if (existingUserByUsername) {
+      throw new ConflictException('Username already exists');
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const user = await this.prisma.user.create({
+      data: {
+        email,
+        username,
+        password: hashedPassword,
+        name,
+      },
+    });
+
+    const payload = { email: user.email, sub: user.id };
+    const access_token = this.jwtService.sign(payload);
+
+    return {
+      access_token,
+      user,
+    };
+  }
+
+  async login(loginInput: LoginInput): Promise<AuthResponse> {
+    const { email, password } = loginInput;
+
+    const user = await this.validateUser(email, password);
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const payload = { email: user.email, sub: user.id };
+    const access_token = this.jwtService.sign(payload);
+
+    return {
+      access_token,
+      user,
+    };
+  }
+
+  async validateUser(email: string, password: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (user && await bcrypt.compare(password, user.password)) {
+      const { password, ...result } = user;
+      return result;
+    }
+    return null;
+  }
+}

--- a/backend/src/auth/dto/auth-response.ts
+++ b/backend/src/auth/dto/auth-response.ts
@@ -1,0 +1,11 @@
+import { ObjectType, Field } from '@nestjs/graphql';
+import { User } from '../../users/entities/user.entity';
+
+@ObjectType()
+export class AuthResponse {
+  @Field()
+  access_token: string;
+
+  @Field(() => User)
+  user: User;
+}

--- a/backend/src/auth/dto/login.input.ts
+++ b/backend/src/auth/dto/login.input.ts
@@ -1,0 +1,13 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+@InputType()
+export class LoginInput {
+  @Field()
+  @IsEmail()
+  email: string;
+
+  @Field()
+  @IsNotEmpty()
+  password: string;
+}

--- a/backend/src/auth/dto/register.input.ts
+++ b/backend/src/auth/dto/register.input.ts
@@ -1,0 +1,20 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+
+@InputType()
+export class RegisterInput {
+  @Field()
+  @IsEmail()
+  email: string;
+
+  @Field()
+  @IsNotEmpty()
+  username: string;
+
+  @Field()
+  @MinLength(6)
+  password: string;
+
+  @Field({ nullable: true })
+  name?: string;
+}

--- a/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,11 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  getRequest(context: ExecutionContext) {
+    const ctx = GqlExecutionContext.create(context);
+    return ctx.getContext().req;
+  }
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { UsersService } from '../../users/users.service';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(private usersService: UsersService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET || 'defaultSecret',
+    });
+  }
+
+  async validate(payload: any) {
+    return this.usersService.findOneById(payload.sub);
+  }
+}

--- a/backend/src/auth/strategies/local.strategy.ts
+++ b/backend/src/auth/strategies/local.strategy.ts
@@ -1,0 +1,21 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-local';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class LocalStrategy extends PassportStrategy(Strategy) {
+  constructor(private authService: AuthService) {
+    super({
+      usernameField: 'email',
+    });
+  }
+
+  async validate(email: string, password: string): Promise<any> {
+    const user = await this.authService.validateUser(email, password);
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    return user;
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -1,15 +1,18 @@
-import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { ObjectType, Field } from '@nestjs/graphql';
 
 @ObjectType()
 export class User {
-  @Field(() => Int)
-  id: number;
-
   @Field()
-  name: string;
+  id: string;
 
   @Field()
   email: string;
+
+  @Field()
+  username: string;
+
+  @Field({ nullable: true })
+  name?: string;
 
   @Field()
   createdAt: Date;

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersResolver } from './users.resolver';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   providers: [UsersService, UsersResolver],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.resolver.ts
+++ b/backend/src/users/users.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Args, Int } from '@nestjs/graphql';
+import { Resolver, Query, Args } from '@nestjs/graphql';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
 
@@ -7,12 +7,12 @@ export class UsersResolver {
   constructor(private readonly usersService: UsersService) {}
 
   @Query(() => [User])
-  users(): User[] {
+  async users(): Promise<User[]> {
     return this.usersService.findAll();
   }
 
-  @Query(() => User)
-  user(@Args('id', { type: () => Int }) id: number): User {
-    return this.usersService.findOne(id);
+  @Query(() => User, { nullable: true })
+  async user(@Args('id') id: string): Promise<User | null> {
+    return this.usersService.findOneById(id);
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,41 +1,30 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
 import { User } from './entities/user.entity';
 
 @Injectable()
 export class UsersService {
-  private readonly users: User[] = [
-    {
-      id: 1,
-      name: '山田太郎',
-      email: 'yamada@example.com',
-      createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01'),
-    },
-    {
-      id: 2,
-      name: '鈴木花子',
-      email: 'suzuki@example.com',
-      createdAt: new Date('2024-01-02'),
-      updatedAt: new Date('2024-01-02'),
-    },
-    {
-      id: 3,
-      name: '佐藤次郎',
-      email: 'sato@example.com',
-      createdAt: new Date('2024-01-03'),
-      updatedAt: new Date('2024-01-03'),
-    },
-  ];
+  constructor(private prisma: PrismaService) {}
 
-  findAll(): User[] {
-    return this.users;
+  async findAll(): Promise<User[]> {
+    return this.prisma.user.findMany();
   }
 
-  findOne(id: number): User {
-    const user = this.users.find((user) => user.id === id);
-    if (!user) {
-      throw new Error(`User with ID ${id} not found`);
-    }
-    return user;
+  async findOneById(id: string): Promise<User | null> {
+    return this.prisma.user.findUnique({
+      where: { id },
+    });
+  }
+
+  async findOneByEmail(email: string): Promise<User | null> {
+    return this.prisma.user.findUnique({
+      where: { email },
+    });
+  }
+
+  async findOneByUsername(username: string): Promise<User | null> {
+    return this.prisma.user.findUnique({
+      where: { username },
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Add username field to User schema with unique constraint
- Implement JWT and local authentication strategies
- Create register mutation with email/username uniqueness validation
- Create login mutation with email/password authentication
- Add password hashing with bcrypt
- Update users service to use Prisma ORM

## Testing

Use GraphQL mutations for registration and login. Make sure to run the Prisma migration and set the JWT_SECRET environment variable.

Closes #6

Generated with [Claude Code](https://claude.ai/code)