### PR TITLE
feat: フロントエンドの日本語対応を実装

### DIFF
--- a/client/src/app/(auth)/login/page.tsx
+++ b/client/src/app/(auth)/login/page.tsx
@@ -27,7 +27,7 @@ const SignupPage = () => {
             {/* Welcome メッセージ */}
             <div className="mb-8">
               <h1 className="text-3xl font-bold text-gray-900 mb-2 font-roboto">
-                Welcome to Vulcan
+                Vulcanへようこそ
               </h1>
               <p className="text-gray-600 text-lg">
                 AI駆動型SaaSプロトタイピングプラットフォーム

--- a/client/src/components/ui/loading.tsx
+++ b/client/src/components/ui/loading.tsx
@@ -34,7 +34,7 @@ interface LoadingProps {
 }
 
 export function Loading({
-  message = "Loading...",
+  message = "読み込み中...",
   size = "md",
   className,
 }: LoadingProps) {
@@ -57,7 +57,7 @@ interface PageLoadingProps {
   message?: string;
 }
 
-export function PageLoading({ message = "Loading..." }: PageLoadingProps) {
+export function PageLoading({ message = "読み込み中..." }: PageLoadingProps) {
   return (
     <div className="min-h-screen flex items-center justify-center">
       <Loading message={message} size="lg" />

--- a/client/src/features/functions/FunctionVariations.tsx
+++ b/client/src/features/functions/FunctionVariations.tsx
@@ -68,19 +68,19 @@ export const FunctionVariations = ({ variations }: Props) => {
               <div className="space-y-3">
                 <div className="grid grid-cols-2 gap-4 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-gray-500">Framework:</span>
+                    <span className="text-gray-500">フレームワーク：</span>
                     <span className="font-medium capitalize">
                       {variation.framework}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500">AI Model:</span>
+                    <span className="text-gray-500">AIモデル：</span>
                     <span className="font-medium">{variation.aiModel}</span>
                   </div>
                 </div>
 
                 <div className="text-sm">
-                  <span className="text-gray-500">Created:</span>
+                  <span className="text-gray-500">作成日：</span>
                   <span className="ml-2">
                     {formatDate(variation.createdAt)}
                   </span>
@@ -106,7 +106,7 @@ export const FunctionVariations = ({ variations }: Props) => {
                   className="flex-1"
                   onClick={() => setPreviewVariation(variation)}
                 >
-                  Preview
+                  プレビュー
                 </Button>
               </div>
             </CardFooter>

--- a/client/src/features/functions/hooks/useCreateVariation.ts
+++ b/client/src/features/functions/hooks/useCreateVariation.ts
@@ -24,7 +24,7 @@ export const useCreateVariation = () => {
       return response.json();
     },
     onError: (error) => {
-      alert("error");
+      alert("エラーが発生しました");
     },
   });
 

--- a/client/src/lib/dateUtils.ts
+++ b/client/src/lib/dateUtils.ts
@@ -60,13 +60,13 @@ export function formatRelativeTime(dateString: string): string {
   const diffInDays = Math.floor(diffInHours / 24);
 
   if (diffInDays > 0) {
-    return `${diffInDays} day${diffInDays > 1 ? "s" : ""} ago`;
+    return `${diffInDays}日前`;
   } else if (diffInHours > 0) {
-    return `${diffInHours} hour${diffInHours > 1 ? "s" : ""} ago`;
+    return `${diffInHours}時間前`;
   } else if (diffInMinutes > 0) {
-    return `${diffInMinutes} minute${diffInMinutes > 1 ? "s" : ""} ago`;
+    return `${diffInMinutes}分前`;
   } else {
-    return "Just now";
+    return "たった今";
   }
 }
 
@@ -82,7 +82,7 @@ export function formatDateHuman(dateString: string): string {
     return dateString;
   }
 
-  return date.toLocaleDateString("en-US", {
+  return date.toLocaleDateString("ja-JP", {
     year: "numeric",
     month: "short",
     day: "numeric",


### PR DESCRIPTION
Issue #16 の対応として、フロントエンドの全てのユーザー向けテキストを日本語にローカライズしました。

## 変更内容
- ログインページのウェルカムメッセージ
- ローディングコンポーネントのデフォルトメッセージ
- 関数バリエーションのラベル類
- 日付ユーティリティの相対時間表示
- エラーメッセージ

すべてのユーザー向けテキストが適切に日本語化されています。

Generated with [Claude Code](https://claude.ai/code)